### PR TITLE
extract to directory and parallel execution

### DIFF
--- a/imgmaker/mpcimg
+++ b/imgmaker/mpcimg
@@ -24,6 +24,7 @@ import shutil
 import subprocess
 import os
 import mmap
+import uuid
 
 comp = ""
 version = ""
@@ -65,11 +66,12 @@ def info(in_update_img):
     if comp != "none":
         print("\nRoofs image is compressed with {}.".format(comp))
 
-def extract(in_update_img, out_img):
+def extract(in_update_img, out_img, out_dir):
 
-    tmp_filename = "imgdata.tmp"
+    tmp_filename = out_dir + str(uuid.uuid4()) + "-imgdata.tmp"
+    outfile = out_dir + out_img
 
-    print("Extracting {} from {}:\n".format(out_img, in_update_img))
+    print("Extracting {} from {}:\n".format(outfile, in_update_img))
     info(in_update_img)
 
     fdtget = ["fdtget", "-t", "x", in_update_img, "/images/rootfs", "data"]
@@ -131,7 +133,7 @@ def extract(in_update_img, out_img):
     # rename rootfs img file if no compression
     if comp == "none" :
         print("3/3.Renaming rootfs img...")
-        os.rename(tmp_filename + ".bin",out_img  )
+        os.rename(tmp_filename + ".bin",outfile)
         return # no compression
 
     # Uncompress the temporary file
@@ -139,10 +141,10 @@ def extract(in_update_img, out_img):
     #filters = [{"id": lzma.FILTER_LZMA2, "preset": 7 | lzma.PRESET_DEFAULT},
 
     with lzma.open(tmp_filename + ".bin",format=lzma.FORMAT_XZ) as compressed:
-        with open(out_img + ".img", 'wb') as destination:
+        with open(outfile + ".img", 'wb') as destination:
             shutil.copyfileobj(compressed, destination)
 
-    print("File ", out_img ," ready in the current directory.")
+    print("File ", outfile ," ready in the current directory.")
 
     print(b," bytes written")
     os.remove(tmp_filename + ".bin")
@@ -259,7 +261,14 @@ if len(sys.argv) > 1:
         exit()
 
     if sys.argv[1] == "extract" and len(sys.argv) == 4:
-        extract(sys.argv[2], "rootfs_" + sys.argv[3])
+        outdir = os.path.dirname(sys.argv[3])
+        basename = sys.argv[3]
+        if outdir is "":
+            outdir = "./"
+        else:
+            basename = os.path.basename(sys.argv[3])
+            outdir = outdir + "/"
+        extract(sys.argv[2], "rootfs_" + basename, outdir)
         print("\nDone !")
         exit()
 


### PR DESCRIPTION
Small pull request to allow extraction to a directory e.g.

```
$ mkdir out
$ mpcimg extract MPC-foobar-Update.img out/foobar
```

Also the `imgdata.tmp` files are randomized, so we can execute the command to the same dir multiple times.