### PR TITLE
inmusic-products-id: add fcc ids from mpc fw 2.14

### DIFF
--- a/MPC/inmusic-products-id
+++ b/MPC/inmusic-products-id
@@ -1,31 +1,29 @@
-ACV0 MPC Rnaissance
-ACV1 MPC Studio
-ACV3 MPC Element
-ACV5 MPC X
-ACV6 MPC Kitten Mattress
-ACV7 MPC Touch
-ACV8 MPC Live
-ACV9 MPC Studio Black
-ACVA MPC Studio Live
-ADA2 Borris The Turtle
-JP07 SC5000 PRIME
-JP08 SC5000M PRIME
-JP12 SC4000 PRIME
-JC11 PRIME 4
-JC16 PRIME 2
-Force (Aka ADA2)
+ACV0          MPC Rnaissance
+ACV1          MPC Studio
+ACV3          MPC Element
+ACV5          MPC X
+ACV5S         MPC X Special Edition
+ACV6          MPC Kitten Mattress
+ACV7          MPC Touch
+ACV8          MPC Live
+ACV9          MPC Studio Black
+ACVA          MPC Studio Live
+ACVA2         MPC One+
+ACVB          MPC Live II
+ACVM          MPC Key 61
+ACVR          MPC Key 37
+ADA2          Borris The Turtle
+JP07          SC5000 PRIME
+JP08          SC5000M PRIME
+JP12          SC4000 PRIME
+JC11          PRIME 4
+JC16          PRIME 2
+Force         (Aka ADA2)
 SC4000
-SC5000 PRIME Screen
-SC5000M PRIME Screen
-SC4000 PRIME Screen
-PRIME 4 Screen
-PRIME 2 Screen
-
+SC5000        PRIME Screen
+SC5000M       PRIME Screen
+SC4000        PRIME Screen
+PRIME         4 Screen
+PRIME         2 Screen
 
 FCC ID is "Y40-(product code)". Ex : for MPC Live : Y40-ACV8.
-
-
-
-
-
-


### PR DESCRIPTION
added the following FCC ids and reformat:
- ACV5S         MPC X Special Edition
- ACVA2         MPC One+
- ACVB          MPC Live II
- ACVM          MPC Key 61
- ACVR          MPC Key 37